### PR TITLE
Updated the path directory for production to remedy issue displaying our client application on Render

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,15 +8,20 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
-    fs: {
-      allow: [
-        // Allow serving files from the project root directory
-        path.resolve(__dirname),
-        // Allow serving files from the client directory
-        path.resolve(__dirname, 'client'),
-        // Allow serving files from the node_modules directory for slick-carousel fonts
-        path.resolve(__dirname, 'node_modules/slick-carousel/slick/fonts'),
-      ],
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false
+      }
     },
+    // fs: {
+    //   allow: [
+    //     // Allow serving files from the project root directory
+    //     path.resolve(__dirname),
+    //     // Allow serving files from the client directory
+    //     path.resolve(__dirname, 'client'),
+    //   ],
+    // },
   },
 })

--- a/server/server.ts
+++ b/server/server.ts
@@ -9,18 +9,18 @@ const db = require('./config/connection')
 
 const startServer = () => {
 	// Middleware
-	app.use(express.urlencoded({ extended: false }));
+	app.use(express.urlencoded({ extended: true }));
 	app.use(express.json());
-	app.use(express.static(path.join(__dirname, '../client/dist')))
+	app.use(express.static(path.join(__dirname, '../client/dist'))) 
 	// app.use(routes)
 
-	app.get("/test", (req: Request, res: Response) => {
+	app.get("/", (req: Request, res: Response) => {
 	  res.send("Express + TypeScript Server");
 	});
 
 	// For production deployment 
 	if (process.env.NODE_ENV === 'production') {
-	app.use(express.static(path.join(__dirname, '../client/dist')));
+	app.use(express.static(path.join(__dirname, '../../client/dist'))); // Requires shifting two levels up because we are deploying from the 'dist' sub-directory
 	}
 
 	db.once('open', () => {
@@ -31,6 +31,3 @@ const startServer = () => {
 };
 
 startServer();
-
-
-


### PR DESCRIPTION
In the server directory:

- Noticed that because we are using TypeScript we have an additional step compiling and exporting to a 'dist' directory. As a result, the project directory hierarchy changes, requiring that we travel one layer higher because `server.js` is in the server's 'dist' sub-directory. 

--------------------------------
In the client directory:

- In `vite.config.ts`, added our API server as a proxy