### PR TITLE
Disabled the 'noEmit' property in the server-level `ts.config.json` file

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -56,8 +56,8 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */


### PR DESCRIPTION
 - Disabled the 'noEmit' property in `ts.config.json` because this prevented the output of the `server.js` file leading to an error when deploying on Render. This error was not caught during author time because I did not receive a build error. `noEmit` is useful when we would like to have a different program such as 'babe' or 'swc' handle compiling and outputting JavaScript. 

- Also, removed comments from compiling in our 'dist' subdirectory's 'server.js' file.