### PR TITLE
When making an API request to our API server when deployed on Render, 404 errors encountered. Adding allowing the proxy's PORT in `vite.config.ts` be pulled from an environmental variable

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ function App() {
     text: string
   }
   const [count, setCount] = useState(0)
+  const [testData, setTestData] = useState('')
 
   const testRequest = async (url: string): Promise<any> => {
     const options: object = {
@@ -17,6 +18,7 @@ function App() {
       const response = await fetch(url, options) // Returns a response object with type, status, etc
       const data: textObject = await response.json() // Must use await otherwise we receive a undefined
       console.log(data.text)
+      setTestData(data.text)
       return data
 
     } catch (err) {
@@ -49,6 +51,7 @@ function App() {
         Click on the Vite and React logos to learn more
       </p>
       <button onClick={() => testRequest('api/text')}>API test</button>
+      <p>{testData}</p>
     </>
   )
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -10,9 +10,9 @@ export default defineConfig({
     open: true,
     proxy: {
       '/api': {
-        target: `http://localhost:${process.env.PORT || 3001}/`,
+        target: process.env.NODE_ENV === 'production' ? process.env.RENDER_EXTERNAL_URL : 'http://localhost:3001/', // When deployed/ in production, we will want to utilize Render's RENDER_EXTERNAL_URL environmental variable provided at runtime. 
         changeOrigin: true,
-        secure: false,
+        secure: process.env.NODE_ENV === 'production' ? true : false, // If we have are in production, secure is 'true', 'false' otherwise
         rewrite: (path) => path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint
       }
     },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     open: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001/',
+        target: `http://localhost:${process.env.PORT || 3001}/`,
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
         target: process.env.NODE_ENV === 'production' ? process.env.RENDER_EXTERNAL_URL : 'http://localhost:3001/', // When deployed/ in production, we will want to utilize Render's RENDER_EXTERNAL_URL environmental variable provided at runtime. 
         changeOrigin: true,
         secure: process.env.NODE_ENV === 'production' ? true : false, // If we have are in production, secure is 'true', 'false' otherwise
-        rewrite: (path) => path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint
+        // When deployed, to access the resource we remove 'api' from the URI. localhost:3001/api/text becomes .onrender.com/text, which is why my fetch requests currently don't work deployed
+        // Rationale below is that when deployed we would like to continue using path to maintain our current fetch request structure and endpoints/routes when developed
+        rewrite: (path) => process.env.NODE_ENV === 'production' ? path : path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint
       }
     },
     // fs: {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         secure: process.env.NODE_ENV === 'production' ? true : false, // If we have are in production, secure is 'true', 'false' otherwise
         // When deployed, to access the resource we remove 'api' from the URI. localhost:3001/api/text becomes .onrender.com/text, which is why my fetch requests currently don't work deployed
         // Rationale below is that when deployed we would like to continue using path to maintain our current fetch request structure and endpoints/routes when developed
-        rewrite: (path) => process.env.NODE_ENV === 'production' ? path : path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint
+        // rewrite: (path) => process.env.NODE_ENV === 'production' ? path : path.replace(/^\/api/, ''), // Required for making the request to the correct API server path and endpoint
       }
     },
     // fs: {

--- a/server/server.ts
+++ b/server/server.ts
@@ -16,7 +16,7 @@ const startServer = () => {
 	// app.use(express.static(path.join(__dirname, '../../client/dist'))) 
 	// app.use(routes)
 
-	app.get("/text", (req: Request, res: Response) => {
+	app.get("/api/text", (req: Request, res: Response) => {
 	  res.json({'text': 'Express + TypeScript Server'});
 	});
 


### PR DESCRIPTION
In the 'client' directory:

- In `vite.config.ts`, added functionality to change the proxy server's target to accept a PORT provided by an environmental variable. With this, I hope that the 404 errors that arose from the deployed Render page are remedied given previously PORT 3001 was hard-coded. 
- In `App.tsx`, I also defined a new state variable and a corresponding paragraph element that is triggered upon a successful API fetch request