### PR TITLE
Defined a series of models for our MongoDB database with four collections: `User`, `DateRecommendation`, `Restaurant`, `Activity`, and `Dessert`

### DIFF
--- a/server/models/Activity.ts
+++ b/server/models/Activity.ts
@@ -1,0 +1,58 @@
+import { Schema, model } from 'mongoose';
+
+const activitySchema = new Schema({
+	yelpId: {
+		type: String,
+		required: true
+	},
+	alias: {
+		type: String,
+		required: true
+	},
+	name: {
+		type: String,
+		required: true
+	},
+	imageUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	yelpUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	rating: {
+		type: Number,
+		required: true
+	},
+	reviewCount: {
+		type: Number,
+		required: true
+	},
+	price: {
+		type: String,
+		required: true
+	},
+	city: {
+		type: String,
+		required: true
+	},
+	country: {
+		type: String, 
+		required: true
+	},
+	state: {
+		type: String, 
+		required: true
+	},
+	displayAddress: {
+		type: String,
+		required: true
+	}
+});
+
+const Activity = model('activity', activitySchema);
+
+module.exports = Activity;

--- a/server/models/DateRecommendation.ts
+++ b/server/models/DateRecommendation.ts
@@ -1,5 +1,4 @@
 import { Schema, model } from 'mongoose';
-const User = require('./User.ts');
 
 const dateRecommendationSchema = new Schema({
 	user: {

--- a/server/models/DateRecommendation.ts
+++ b/server/models/DateRecommendation.ts
@@ -1,0 +1,48 @@
+import { Schema, model } from 'mongoose';
+const User = require('./User.ts');
+
+const dateRecommendationSchema = new Schema({
+	user: {
+		type: Schema.Types.ObjectId,
+		ref: 'User',
+		required: true
+	},
+	date: {
+		type: Date,
+		default: Date.now()
+	},
+	location: {
+		type: String,
+	},
+	latitude: {
+		type: Number,
+		min: -90,
+		max: 90
+	},
+	longitude: {
+		type: Number,
+		min: -180,
+		max: 180
+	},
+	restaurant: {
+		type: Schema.Types.ObjectId,
+		ref: 'Restaurant'
+		// Not making these required to allow user flexibility to select only fields of interest
+	},
+	activity: {
+		type: Schema.Types.ObjectId,
+		ref: 'Activity'
+	},
+	dessert: {
+		type: Schema.Types.ObjectId,
+		ref: 'Dessert'
+	},
+	favorite: {
+		type: Boolean,
+		default: false
+	}
+});
+
+const DateRecommendation = model('dateRecommendation', dateRecommendationSchema);
+
+module.exports = DateRecommendation;

--- a/server/models/Dessert.ts
+++ b/server/models/Dessert.ts
@@ -1,0 +1,58 @@
+import { Schema, model } from 'mongoose';
+
+const dessertSchema = new Schema({
+	yelpId: {
+		type: String,
+		required: true
+	},
+	alias: {
+		type: String,
+		required: true
+	},
+	name: {
+		type: String,
+		required: true
+	},
+	imageUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	yelpUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	rating: {
+		type: Number,
+		required: true
+	},
+	reviewCount: {
+		type: Number,
+		required: true
+	},
+	price: {
+		type: String,
+		required: true
+	},
+	city: {
+		type: String,
+		required: true
+	},
+	country: {
+		type: String, 
+		required: true
+	},
+	state: {
+		type: String, 
+		required: true
+	},
+	displayAddress: {
+		type: String,
+		required: true
+	}
+});
+
+const Dessert = model('dessert', dessertSchema);
+
+module.exports = Dessert;

--- a/server/models/Restaurant.ts
+++ b/server/models/Restaurant.ts
@@ -1,0 +1,58 @@
+import { Schema, model } from 'mongoose';
+
+const restaurantSchema = new Schema({
+	yelpId: {
+		type: String,
+		required: true
+	},
+	alias: {
+		type: String,
+		required: true
+	},
+	name: {
+		type: String,
+		required: true
+	},
+	imageUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	yelpUrl: {
+		type: String,
+		required: true,
+		match: [/(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/, 'Must match a URL']
+	},
+	rating: {
+		type: Number,
+		required: true
+	},
+	reviewCount: {
+		type: Number,
+		required: true
+	},
+	price: {
+		type: String,
+		required: true
+	},
+	city: {
+		type: String,
+		required: true
+	},
+	country: {
+		type: String, 
+		required: true
+	},
+	state: {
+		type: String, 
+		required: true
+	},
+	displayAddress: {
+		type: String,
+		required: true
+	}
+});
+
+const Restaurant = model('restaurant', restaurantSchema);
+
+module.exports = Restaurant;

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,5 +1,6 @@
 import { Schema, model } from 'mongoose';
-
+const DateRecommendation = require('./DateRecommendation.ts')
+ 
 const userSchema = new Schema ({
 	email: {
 		type: String,
@@ -14,7 +15,7 @@ const userSchema = new Schema ({
 	dates: [
 		{
 			type: Schema.Types.ObjectId,
-			ref: 'date'	
+			ref: 'DateRecommendation'	
 		}
 	]
 });

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,5 +1,4 @@
 import { Schema, model } from 'mongoose';
-const DateRecommendation = require('./DateRecommendation.ts')
  
 const userSchema = new Schema ({
 	email: {

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,0 +1,28 @@
+import { Schema, model } from 'mongoose';
+
+const userSchema = new Schema ({
+	email: {
+		type: String,
+		required: true, 
+		unique: true,
+		match: [/.+@.+\..+/, 'Must match an email address!']
+	},
+	password: {
+		type: String,
+		required: true, 
+	}, 
+	dates: [
+		{
+			type: Schema.Types.ObjectId,
+			ref: 'date'	
+		}
+	]
+});
+
+// If we build our own authentication, we will define a 'pre' middleware to salt and hash the password using bycrpt
+// We would also require the `isCorrectPassword` function
+// As I am interested in using Auth0, must review documentation
+
+const User = model('user', userSchema)
+
+module.exports = User;

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -1,5 +1,6 @@
 const User = require('./User.ts')
 const DateRecommendation = require('./DateRecommendation.ts');
 const Restaurant = require('./Restaurant.ts');
+const Activity = require('./Activity.ts');
 
 module.exports = { User, DateRecommendation }

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -1,0 +1,3 @@
+import User from 'User.ts'
+
+module.exports = { User }

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -1,4 +1,5 @@
 const User = require('./User.ts')
 const DateRecommendation = require('./DateRecommendation.ts');
+const Restaurant = require('./Restaurant.ts');
 
 module.exports = { User, DateRecommendation }

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -2,5 +2,6 @@ const User = require('./User.ts')
 const DateRecommendation = require('./DateRecommendation.ts');
 const Restaurant = require('./Restaurant.ts');
 const Activity = require('./Activity.ts');
+const Dessert = require('./Dessert.ts');
 
-module.exports = { User, DateRecommendation }
+module.exports = { User, DateRecommendation, Restaurant, Activity, Dessert }

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -1,3 +1,4 @@
-import User from 'User.ts'
+const User = require('./User.ts')
+const DateRecommendation = require('./DateRecommendation.ts');
 
-module.exports = { User }
+module.exports = { User, DateRecommendation }

--- a/server/server.ts
+++ b/server/server.ts
@@ -29,6 +29,11 @@ const startServer = () => {
 		// })
 	}
 
+	// Evaluate if this is best implemented through the API server or React's router 
+	app.use('*', (req: Request, res: Response) => {
+			res.sendFile(path.join(__dirname, '../../client/dist/index.html'))
+		})
+	
 	db.once('open', () => {
 		app.listen(PORT, () => {
 	  	console.log(`API server running on port ${PORT}`);


### PR DESCRIPTION
In the 'server' directory, I created a "models" sub-directory where we define a series of schema, models, and collections.

- Defined a 'User' schema that includes an email, a password, and an array of Appointment ObjectIds
    - Currently, I have not salt and hashed the passwords because I intend to implement Auth0 and will need to reference further documentation to store the user information ourselves 
- Defined an 'Appointment' schema that contains a reference to a user, the recommendation's date, references to a restaurant, a activity, and a dessert. We also collect location information, either the string provided by the user or geolocation coordinations. Users can also mark these documents as a "favorite"
- Defined three schemas and models for "restaurant", "activity", and "dessert".
    -  These contain the same fields and, although they can be placed in one large collection of businesses, for organizational purposes and references I have separated these into three separate collections. 
    - Ideally, this will make updating and referencing organizations easier
    - Relevant information is collected and stored so that we do not need to make further requests to Yelp API when users review past recommendations 